### PR TITLE
Components/basic layout style bug fix

### DIFF
--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -83,18 +83,18 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
         </div>
       </div>
 
-      <main className={"h-full"}>{children}</main>
-      {/* w-[calc(100%-" +
-          MENU_BAR_WIDTH +
-          "px)] md:w-[calc(100%-" +
-          MENU_BAR_WIDTH_MD +
-          "px)] lg:w-[calc(100%-" +
-          MENU_BAR_WIDTH_LG +
-          "px)] xl:w-[calc(100%-" +
-          MENU_BAR_WIDTH_XL +
-          "px)] 2xl:w-[calc(100%-" +
-          MENU_BAR_WIDTH_2XL +
-          "px)] */}
+      <main
+        className={classNames(
+          "h-full",
+          MAIN_W_CLASS,
+          MAIN_W_CLASS_MD,
+          MAIN_W_CLASS_LG,
+          MAIN_W_CLASS_XL,
+          MAIN_W_CLASS_2XL
+        )}
+      >
+        {children}
+      </main>
     </div>
   );
 };

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -11,12 +11,6 @@ const MENU_BAR_W_LG: number = 282;
 const MENU_BAR_W_XL: number = 352;
 const MENU_BAR_W_2XL: number = 422;
 
-const menuBarWClass: string = "w-[" + MENU_BAR_W + "px]";
-const menuBarWClassMd: string = "md:w-[" + MENU_BAR_W_MD + "px]";
-const menuBarWClassLg: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
-const menuBarWClassXl: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
-const menuBarWClass2xl: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
-
 const mainWClass: string = "w-[calc(100%-" + MENU_BAR_W + "px)]";
 const mainWClassMd: string = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
 const mainWClassLg: string = "lg:w-[calc(100%-" + MENU_BAR_W_LG + "px)]";

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -12,6 +12,7 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   return (
     <div className="flex w-screen h-screen">
       <div className="flex flex-row-reverse w-[176px] md:w-[211px] lg:w-[282px] xl:w-[352px] 2xl:w-[422px] h-full">
+        {/* note: 上のdivのwidthの値を変更する場合、<main>のwidthの値も変更すること。*/}
         <div className="pl-[7%] w-[82%] h-full bg-gradient-to-b from-theme-start to-theme-end">
           <h2 className="my-[13%] text-[11px] md:text-[13px] lg:text-[18px] xl:text-[22px] 2xl:text-[27px] text-white font-bold leading-basic">
             コンピュータ研究部

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -5,24 +5,6 @@ import { LayoutProps } from "../../types";
 import { MenuItemIcon } from "..";
 import { MENUS_ITEMS } from "../../constants";
 
-const MENU_BAR_W = 176;
-const MENU_BAR_W_MD = 211;
-const MENU_BAR_W_LG = 282;
-const MENU_BAR_W_XL = 352;
-const MENU_BAR_W_2XL = 422;
-
-const menuBarWClass = "w-[" + MENU_BAR_W + "px]";
-const menuBarWClassMd = "md:w-[" + MENU_BAR_W_MD + "px]";
-const menuBarWClassLg = "lg:w-[" + MENU_BAR_W_LG + "px]";
-const menuBarWClassXl = "xl:w-[" + MENU_BAR_W_XL + "px]";
-const menuBarWClass2xl = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
-
-const mainWClass = "w-[calc(100%-" + MENU_BAR_W + "px)]";
-const mainWClassMd = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
-const mainWClassLg = "lg:w-[calc(100%-" + MENU_BAR_W_LG + "px)]";
-const mainWClassXl = "xl:w-[calc(100%-" + MENU_BAR_W_XL + "px)]";
-const mainWClass2xl = "2xl:w-[calc(100%-" + MENU_BAR_W_2XL + "px)]";
-
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,
   children,

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -64,7 +64,11 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
         </div>
       </div>
 
-      <main className={"h-full"}>{children}</main>
+      <main
+        className={`w-[calc(100%-${MENU_BAR_W}px)] md:w-[calc(100%-${MENU_BAR_W_MD}px)] lg:w-[calc(100%-${MENU_BAR_W_LG}px)] xl:w-[calc(100%-${MENU_BAR_W_XL}px)] 2xl:w-[calc(100%-${MENU_BAR_W_2XL}px)] h-full`}
+      >
+        {children}
+      </main>
     </div>
   );
 };

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -11,6 +11,12 @@ const MENU_BAR_W_LG: number = 282;
 const MENU_BAR_W_XL: number = 352;
 const MENU_BAR_W_2XL: number = 422;
 
+const MENU_BAR_W_CLASS: string = "w-[" + MENU_BAR_W + "px]";
+const MENU_BAR_W_CLASS_MD: string = "md:w-[" + MENU_BAR_W_MD + "px]";
+const MENU_BAR_W_CLASS_LG: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
+const MENU_BAR_W_CLASS_XL: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
+const MENU_BAR_W_CLASS_2XL: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
+
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,
   children,

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -73,9 +73,8 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
         </div>
       </div>
 
-      <main
-        className={
-          "w-[calc(100%-" +
+      <main className={"h-full"}>{children}</main>
+      {/* w-[calc(100%-" +
           MENU_BAR_WIDTH +
           "px)] md:w-[calc(100%-" +
           MENU_BAR_WIDTH_MD +
@@ -85,11 +84,7 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
           MENU_BAR_WIDTH_XL +
           "px)] 2xl:w-[calc(100%-" +
           MENU_BAR_WIDTH_2XL +
-          "px)] h-full"
-        }
-      >
-        {children}
-      </main>
+          "px)] */}
     </div>
   );
 };

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -11,17 +11,17 @@ const MENU_BAR_W_LG = 282;
 const MENU_BAR_W_XL = 352;
 const MENU_BAR_W_2XL = 422;
 
-const menuBarWClass: string = "w-[" + MENU_BAR_W + "px]";
-const menuBarWClassMd: string = "md:w-[" + MENU_BAR_W_MD + "px]";
-const menuBarWClassLg: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
-const menuBarWClassXl: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
-const menuBarWClass2xl: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
+const menuBarWClass = "w-[" + MENU_BAR_W + "px]";
+const menuBarWClassMd = "md:w-[" + MENU_BAR_W_MD + "px]";
+const menuBarWClassLg = "lg:w-[" + MENU_BAR_W_LG + "px]";
+const menuBarWClassXl = "xl:w-[" + MENU_BAR_W_XL + "px]";
+const menuBarWClass2xl = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
 
-const mainWClass: string = "w-[calc(100%-" + MENU_BAR_W + "px)]";
-const mainWClassMd: string = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
-const mainWClassLg: string = "lg:w-[calc(100%-" + MENU_BAR_W_LG + "px)]";
-const mainWClassXl: string = "xl:w-[calc(100%-" + MENU_BAR_W_XL + "px)]";
-const mainWClass2xl: string = "2xl:w-[calc(100%-" + MENU_BAR_W_2XL + "px)]";
+const mainWClass = "w-[calc(100%-" + MENU_BAR_W + "px)]";
+const mainWClassMd = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
+const mainWClassLg = "lg:w-[calc(100%-" + MENU_BAR_W_LG + "px)]";
+const mainWClassXl = "xl:w-[calc(100%-" + MENU_BAR_W_XL + "px)]";
+const mainWClass2xl = "2xl:w-[calc(100%-" + MENU_BAR_W_2XL + "px)]";
 
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -32,10 +32,10 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
       <div
         className={classNames(
           "flex flex-row-reverse h-full",
-          menuBarWClass,
-          menuBarWClassMd,
-          menuBarWClassLg,
-          menuBarWClassXl,
+          "w-[176px]",
+          "md:w-[211px]",
+          "lg:w-[282px]",
+          "xl:w-[352px]",
           menuBarWClass2xl
         )}
       >

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -74,18 +74,7 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
         </div>
       </div>
 
-      <main
-        className={classNames(
-          "h-full",
-          mainWClass,
-          mainWClassMd,
-          mainWClassLg,
-          mainWClassXl,
-          mainWClass2xl
-        )}
-      >
-        {children}
-      </main>
+      <main className={"h-full"}>{children}</main>
     </div>
   );
 };

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -29,16 +29,7 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
 }) => {
   return (
     <div className="flex w-screen h-screen">
-      <div
-        className={classNames(
-          "flex flex-row-reverse h-full",
-          menuBarWClass,
-          menuBarWClassMd,
-          menuBarWClassLg,
-          menuBarWClassXl,
-          menuBarWClass2xl
-        )}
-      >
+      <div className={"flex flex-row-reverse h-full"}>
         <div className="pl-[7%] w-[82%] h-full bg-gradient-to-b from-theme-start to-theme-end">
           <h2 className="my-[13%] text-[11px] md:text-[13px] lg:text-[18px] xl:text-[22px] 2xl:text-[27px] text-white font-bold leading-basic">
             コンピュータ研究部

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -17,11 +17,11 @@ const menuBarWClassLg: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
 const menuBarWClassXl: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
 const menuBarWClass2xl: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
 
-const MAIN_W_CLASS: string = "w-[calc(100%-" + MENU_BAR_W + "px)]";
-const MAIN_W_CLASS_MD: string = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
-const MAIN_W_CLASS_LG: string = "lg:w-[calc(100%-" + MENU_BAR_W_LG + "px)]";
-const MAIN_W_CLASS_XL: string = "xl:w-[calc(100%-" + MENU_BAR_W_XL + "px)]";
-const MAIN_W_CLASS_2XL: string = "2xl:w-[calc(100%-" + MENU_BAR_W_2XL + "px)]";
+const mainWClass: string = "w-[calc(100%-" + MENU_BAR_W + "px)]";
+const mainWClassMd: string = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
+const mainWClassLg: string = "lg:w-[calc(100%-" + MENU_BAR_W_LG + "px)]";
+const mainWClassXl: string = "xl:w-[calc(100%-" + MENU_BAR_W_XL + "px)]";
+const mainWClass2xl: string = "2xl:w-[calc(100%-" + MENU_BAR_W_2XL + "px)]";
 
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,
@@ -86,11 +86,11 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
       <main
         className={classNames(
           "h-full",
-          MAIN_W_CLASS,
-          MAIN_W_CLASS_MD,
-          MAIN_W_CLASS_LG,
-          MAIN_W_CLASS_XL,
-          MAIN_W_CLASS_2XL
+          mainWClass,
+          mainWClassMd,
+          mainWClassLg,
+          mainWClassXl,
+          mainWClass2xl
         )}
       >
         {children}

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -74,16 +74,7 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
         </div>
       </div>
 
-      <main
-        className={classNames(
-          "h-full",
-          mainWClass,
-          mainWClassMd,
-          mainWClassLg,
-          mainWClassXl,
-          mainWClass2xl
-        )}
-      >
+      <main className="w-[calc(100%-176px)] md:w-[calc(100%-211px)] lg:w-[calc(100%-282px)] xl:w-[calc(100%-352px)] 2xl:w-[calc(100%-422px)] h-full">
         {children}
       </main>
     </div>

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -17,6 +17,12 @@ const MENU_BAR_W_CLASS_LG: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
 const MENU_BAR_W_CLASS_XL: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
 const MENU_BAR_W_CLASS_2XL: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
 
+const MAIN_W_CLASS: string = "w-[" + MENU_BAR_W + "px]";
+const MAIN_W_CLASS_MD: string = "md:w-[" + MENU_BAR_W_MD + "px]";
+const MAIN_W_CLASS_LG: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
+const MAIN_W_CLASS_XL: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
+const MAIN_W_CLASS_2XL: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
+
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,
   children,

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -5,11 +5,11 @@ import { LayoutProps } from "../../types";
 import { MenuItemIcon } from "..";
 import { MENUS_ITEMS } from "../../constants";
 
-const MENU_BAR_WIDTH: string = "176";
-const MENU_BAR_WIDTH_MD: string = "211";
-const MENU_BAR_WIDTH_LG: string = "282";
-const MENU_BAR_WIDTH_XL: string = "352";
-const MENU_BAR_WIDTH_2XL: string = "422";
+const MENU_BAR_WIDTH: number = 176;
+const MENU_BAR_WIDTH_MD: number = 211;
+const MENU_BAR_WIDTH_LG: number = 282;
+const MENU_BAR_WIDTH_XL: number = 352;
+const MENU_BAR_WIDTH_2XL: number = 422;
 
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -17,9 +17,8 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
 }) => {
   return (
     <div className="flex w-screen h-screen">
-      <div
-        className={
-          "flex flex-row-reverse w-[" +
+      <div className={"flex flex-row-reverse h-full"}>
+        {/* w-[" +
           MENU_BAR_WIDTH +
           "px] md:w-[" +
           MENU_BAR_WIDTH_MD +
@@ -29,9 +28,7 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
           MENU_BAR_WIDTH_XL +
           "px] 2xl:w-[" +
           MENU_BAR_WIDTH_2XL +
-          "px] h-full"
-        }
-      >
+          "px] */}
         <div className="pl-[7%] w-[82%] h-full bg-gradient-to-b from-theme-start to-theme-end">
           <h2 className="my-[13%] text-[11px] md:text-[13px] lg:text-[18px] xl:text-[22px] 2xl:text-[27px] text-white font-bold leading-basic">
             コンピュータ研究部

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -17,11 +17,11 @@ const MENU_BAR_W_CLASS_LG: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
 const MENU_BAR_W_CLASS_XL: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
 const MENU_BAR_W_CLASS_2XL: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
 
-const MAIN_W_CLASS: string = "w-[" + MENU_BAR_W + "px]";
-const MAIN_W_CLASS_MD: string = "md:w-[" + MENU_BAR_W_MD + "px]";
-const MAIN_W_CLASS_LG: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
-const MAIN_W_CLASS_XL: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
-const MAIN_W_CLASS_2XL: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
+const MAIN_W_CLASS: string = "w-[calc(100%-" + MENU_BAR_W + "px)]";
+const MAIN_W_CLASS_MD: string = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
+const MAIN_W_CLASS_LG: string = "lg:w-[calc(100%-" + MENU_BAR_W_LG + "px)]";
+const MAIN_W_CLASS_XL: string = "xl:w-[calc(100%-" + MENU_BAR_W_XL + "px)]";
+const MAIN_W_CLASS_2XL: string = "2xl:w-[calc(100%-" + MENU_BAR_W_2XL + "px)]";
 
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -17,7 +17,9 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
 }) => {
   return (
     <div className="flex w-screen h-screen">
-      <div className={"flex flex-row-reverse h-full"}>
+      <div
+        className={`flex flex-row-reverse w-[${MENU_BAR_W}px] md:w-[${MENU_BAR_W_MD}px] lg:w-[${MENU_BAR_W_LG}px] xl:w-[${MENU_BAR_W_XL}px] 2xl:w-[${MENU_BAR_W_2XL}px] h-full`}
+      >
         <div className="pl-[7%] w-[82%] h-full bg-gradient-to-b from-theme-start to-theme-end">
           <h2 className="my-[13%] text-[11px] md:text-[13px] lg:text-[18px] xl:text-[22px] 2xl:text-[27px] text-white font-bold leading-basic">
             コンピュータ研究部

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -29,16 +29,7 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
 }) => {
   return (
     <div className="flex w-screen h-screen">
-      <div
-        className={classNames(
-          "flex flex-row-reverse h-full",
-          "w-[176px]",
-          "md:w-[211px]",
-          "lg:w-[282px]",
-          "xl:w-[352px]",
-          menuBarWClass2xl
-        )}
-      >
+      <div className="flex flex-row-reverse w-[176px] md:w-[211px] lg:w-[282px] xl:w-[352px] 2xl:w-[422px] h-full">
         <div className="pl-[7%] w-[82%] h-full bg-gradient-to-b from-theme-start to-theme-end">
           <h2 className="my-[13%] text-[11px] md:text-[13px] lg:text-[18px] xl:text-[22px] 2xl:text-[27px] text-white font-bold leading-basic">
             コンピュータ研究部

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -58,6 +58,7 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
       </div>
 
       <main className="w-[calc(100%-176px)] md:w-[calc(100%-211px)] lg:w-[calc(100%-282px)] xl:w-[calc(100%-352px)] 2xl:w-[calc(100%-422px)] h-full">
+        {/* note: <main className = "w-[calc(100%-n px)]… n: メニューバースペースのdivのwidth */}
         {children}
       </main>
     </div>

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -11,11 +11,11 @@ const MENU_BAR_W_LG: number = 282;
 const MENU_BAR_W_XL: number = 352;
 const MENU_BAR_W_2XL: number = 422;
 
-const MENU_BAR_W_CLASS: string = "w-[" + MENU_BAR_W + "px]";
-const MENU_BAR_W_CLASS_MD: string = "md:w-[" + MENU_BAR_W_MD + "px]";
-const MENU_BAR_W_CLASS_LG: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
-const MENU_BAR_W_CLASS_XL: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
-const MENU_BAR_W_CLASS_2XL: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
+const menuBarWClass: string = "w-[" + MENU_BAR_W + "px]";
+const menuBarWClassMd: string = "md:w-[" + MENU_BAR_W_MD + "px]";
+const menuBarWClassLg: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
+const menuBarWClassXl: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
+const menuBarWClass2xl: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
 
 const MAIN_W_CLASS: string = "w-[calc(100%-" + MENU_BAR_W + "px)]";
 const MAIN_W_CLASS_MD: string = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
@@ -32,11 +32,11 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
       <div
         className={classNames(
           "flex flex-row-reverse h-full",
-          MENU_BAR_W_CLASS,
-          MENU_BAR_W_CLASS_MD,
-          MENU_BAR_W_CLASS_LG,
-          MENU_BAR_W_CLASS_XL,
-          MENU_BAR_W_CLASS_2XL
+          menuBarWClass,
+          menuBarWClassMd,
+          menuBarWClassLg,
+          menuBarWClassXl,
+          menuBarWClass2xl
         )}
       >
         <div className="pl-[7%] w-[82%] h-full bg-gradient-to-b from-theme-start to-theme-end">

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -5,11 +5,11 @@ import { LayoutProps } from "../../types";
 import { MenuItemIcon } from "..";
 import { MENUS_ITEMS } from "../../constants";
 
-const MENU_BAR_WIDTH: number = 176;
-const MENU_BAR_WIDTH_MD: number = 211;
-const MENU_BAR_WIDTH_LG: number = 282;
-const MENU_BAR_WIDTH_XL: number = 352;
-const MENU_BAR_WIDTH_2XL: number = 422;
+const MENU_BAR_W: number = 176;
+const MENU_BAR_W_MD: number = 211;
+const MENU_BAR_W_LG: number = 282;
+const MENU_BAR_W_XL: number = 352;
+const MENU_BAR_W_2XL: number = 422;
 
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -11,12 +11,6 @@ const MENU_BAR_W_LG: number = 282;
 const MENU_BAR_W_XL: number = 352;
 const MENU_BAR_W_2XL: number = 422;
 
-const mainWClass: string = "w-[calc(100%-" + MENU_BAR_W + "px)]";
-const mainWClassMd: string = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
-const mainWClassLg: string = "lg:w-[calc(100%-" + MENU_BAR_W_LG + "px)]";
-const mainWClassXl: string = "xl:w-[calc(100%-" + MENU_BAR_W_XL + "px)]";
-const mainWClass2xl: string = "2xl:w-[calc(100%-" + MENU_BAR_W_2XL + "px)]";
-
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,
   children,

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -5,11 +5,11 @@ import { LayoutProps } from "../../types";
 import { MenuItemIcon } from "..";
 import { MENUS_ITEMS } from "../../constants";
 
-const MENU_BAR_W: number = 176;
-const MENU_BAR_W_MD: number = 211;
-const MENU_BAR_W_LG: number = 282;
-const MENU_BAR_W_XL: number = 352;
-const MENU_BAR_W_2XL: number = 422;
+const MENU_BAR_W = 176;
+const MENU_BAR_W_MD = 211;
+const MENU_BAR_W_LG = 282;
+const MENU_BAR_W_XL = 352;
+const MENU_BAR_W_2XL = 422;
 
 const menuBarWClass: string = "w-[" + MENU_BAR_W + "px]";
 const menuBarWClassMd: string = "md:w-[" + MENU_BAR_W_MD + "px]";

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -11,6 +11,18 @@ const MENU_BAR_W_LG: number = 282;
 const MENU_BAR_W_XL: number = 352;
 const MENU_BAR_W_2XL: number = 422;
 
+const menuBarWClass: string = "w-[" + MENU_BAR_W + "px]";
+const menuBarWClassMd: string = "md:w-[" + MENU_BAR_W_MD + "px]";
+const menuBarWClassLg: string = "lg:w-[" + MENU_BAR_W_LG + "px]";
+const menuBarWClassXl: string = "xl:w-[" + MENU_BAR_W_XL + "px]";
+const menuBarWClass2xl: string = "2xl:w-[" + MENU_BAR_W_2XL + "px]";
+
+const mainWClass: string = "w-[calc(100%-" + MENU_BAR_W + "px)]";
+const mainWClassMd: string = "md:w-[calc(100%-" + MENU_BAR_W_MD + "px)]";
+const mainWClassLg: string = "lg:w-[calc(100%-" + MENU_BAR_W_LG + "px)]";
+const mainWClassXl: string = "xl:w-[calc(100%-" + MENU_BAR_W_XL + "px)]";
+const mainWClass2xl: string = "2xl:w-[calc(100%-" + MENU_BAR_W_2XL + "px)]";
+
 export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   type,
   children,
@@ -18,7 +30,14 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
   return (
     <div className="flex w-screen h-screen">
       <div
-        className={`flex flex-row-reverse w-[${MENU_BAR_W}px] md:w-[${MENU_BAR_W_MD}px] lg:w-[${MENU_BAR_W_LG}px] xl:w-[${MENU_BAR_W_XL}px] 2xl:w-[${MENU_BAR_W_2XL}px] h-full`}
+        className={classNames(
+          "flex flex-row-reverse h-full",
+          menuBarWClass,
+          menuBarWClassMd,
+          menuBarWClassLg,
+          menuBarWClassXl,
+          menuBarWClass2xl
+        )}
       >
         <div className="pl-[7%] w-[82%] h-full bg-gradient-to-b from-theme-start to-theme-end">
           <h2 className="my-[13%] text-[11px] md:text-[13px] lg:text-[18px] xl:text-[22px] 2xl:text-[27px] text-white font-bold leading-basic">
@@ -65,7 +84,14 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
       </div>
 
       <main
-        className={`w-[calc(100%-${MENU_BAR_W}px)] md:w-[calc(100%-${MENU_BAR_W_MD}px)] lg:w-[calc(100%-${MENU_BAR_W_LG}px)] xl:w-[calc(100%-${MENU_BAR_W_XL}px)] 2xl:w-[calc(100%-${MENU_BAR_W_2XL}px)] h-full`}
+        className={classNames(
+          "h-full",
+          mainWClass,
+          mainWClassMd,
+          mainWClassLg,
+          mainWClassXl,
+          mainWClass2xl
+        )}
       >
         {children}
       </main>

--- a/components/layouts/Basic.tsx
+++ b/components/layouts/Basic.tsx
@@ -29,18 +29,16 @@ export const BasicLayout: ({ type, children }: LayoutProps) => JSX.Element = ({
 }) => {
   return (
     <div className="flex w-screen h-screen">
-      <div className={"flex flex-row-reverse h-full"}>
-        {/* w-[" +
-          MENU_BAR_WIDTH +
-          "px] md:w-[" +
-          MENU_BAR_WIDTH_MD +
-          "px] lg:w-[" +
-          MENU_BAR_WIDTH_LG +
-          "px] xl:w-[" +
-          MENU_BAR_WIDTH_XL +
-          "px] 2xl:w-[" +
-          MENU_BAR_WIDTH_2XL +
-          "px] */}
+      <div
+        className={classNames(
+          "flex flex-row-reverse h-full",
+          MENU_BAR_W_CLASS,
+          MENU_BAR_W_CLASS_MD,
+          MENU_BAR_W_CLASS_LG,
+          MENU_BAR_W_CLASS_XL,
+          MENU_BAR_W_CLASS_2XL
+        )}
+      >
         <div className="pl-[7%] w-[82%] h-full bg-gradient-to-b from-theme-start to-theme-end">
           <h2 className="my-[13%] text-[11px] md:text-[13px] lg:text-[18px] xl:text-[22px] 2xl:text-[27px] text-white font-bold leading-basic">
             コンピュータ研究部


### PR DESCRIPTION
<!-- https://github.com/Conken-NitKit/github-template-example/blob/main/.github/PULL_REQUEST_TEMPLATE_REACT.md より -->

## 概要

<!-- 今回のPRの 実装内容 & 変更するに至った背景 を記載してください。 -->

　className内に変数や定数がある場合に、クラスが適用されないことがある不具合を修正しました。

　またこの不具合は、上のコードを含むコードを、`develop`から切った新しいブランチにpullして、`yarn dev`し直すと発生します。

## デバッグ項目

<!--
実装に不具合がないことを確認するために行った項目です。

- [ ] 入力例 1
- [ ] 入力例 2
-->

　`develop`から新しいローカルブランチを切って、`yarn dev`し直しました。
　不具合は起こりませんでした。

## スクリーンショット

<!--
実際にどのような表示かの写真を貼り付ける項目です。
動画の場合は下記の表を消して、[この記事](https://zenn.dev/naminodarie/articles/27f9c260fd81fd)を参考に動画を追加してください。
-->

なし。

## 参考 URL

<!--
参考にした記事があれば、そのURLを記載してください。

- 参考にしたURL 1
- 参考にしたURL 2
-->

なし。

## Self-Checking points 🚨

レビューを依頼する前に必ず確認してほしいポイントです。
一般的な項目を上げているので、プロジェクト毎に必要なポイントがあれば各リポジトリで追加してください。

### 共通 (命名)

- [x] `data`, `info`, `value` などの汎用的で抽象度の高い変数名を使っていない → [参考](https://neos21.net/blog/2020/01/28-01.html)
- [x] 配列には末尾に `s` をつけて複数形にするか `xxxList` と命名することで配列であることを明確にしている → [参考](https://teratail.com/questions/161176)
- [x] マジックナンバーは極力存在せず、定数を用いて表現されている [参考](https://twitter.com/program_shiba/status/1483378634975072260)
- [x] パッと見で何をやってるかわからないような処理の結果を **説明変数** している → [参考](https://wb-hp.com/blog/2020/11/09/explanatory-variable.html)
- [x] 複雑な条件式の結果を **要約変数** を適用している → [参考](https://twitter.com/hakuto00/status/1362608154840760320)

### 共通 (処理系)

- [x] **早期リターン（ガード節）** を適用することで条件分岐の簡略化している → [参考](https://zenn.dev/media_engine/articles/early_return)
- [x] if 文では「調査対象」を左側に、「比較対象」を右側に配置している → [参考](https://twitter.com/yuuuma_11/status/1347374986160340992/photo/2)
- [x] 値のパターンによって分岐する場合は `is/else文` ではなく、`switch文` を使う → [参考](https://blog.senseshare.jp/if-switch.html)

### 共通 (コメント系)

- [x] コメントには適切なアノテーションコメントが記載されている → [参考](https://qiita.com/taka-kawa/items/673716d77795c937d422)

### JavaScript (命名)

- [x] 変数名, 関数名, プロパティ名 は `ローワーキャメルケース` になっている → [参考](https://qiita.com/RyosukeSomeya/items/90f8e780b37c53758276)
- [x] クラス名, オブジェクト名 は `パスカルケース` になっている → [参考](https://qiita.com/RyosukeSomeya/items/90f8e780b37c53758276)
- [x] 定数名は `スネークケース` になっている → [参考](https://qiita.com/RyosukeSomeya/items/90f8e780b37c53758276)

### JavaScript (処理系)

- [x] 変数の宣言には極力を `const` を利用している → [参考](https://qiita.com/cheez921/items/7b57835cb76e70dd0fc4)
- [x] 文字列の合成にはテンプレートリテラルを利用している → [参考](https://qiita.com/kitamuwork/items/6830c1fe2399f35fce8d)
- [x] ループ処理は `通常for文`, `for-in`, `forEach` などは極力利用せず、高階関数を利用している → [参考](https://qiita.com/may88seiji/items/8f7e42353b6904af5e9a)
- [x] `==(等価演算子)` は使わず `===(厳密等価演算子)` を利用している → [参考](https://code-graffiti.com/equality-operators-in-javascript/)

### TypeScript (命名)

- [x] インターフェース, タイプ, Enum の命名は `パスカルケース` になっている → [参考](https://typescript-jp.gitbook.io/deep-dive/styleguide)

### React (処理系)

- [x] コンポーネントの変数名は `パスカルケース` になっている → [参考](https://qiita.com/RyosukeSomeya/items/90f8e780b37c53758276)
- [x] イベント処理のロジックは JSX 内に直接かかず、コールバック関数として JSX 外で定義する → [参考](https://qiita.com/baby-degu/items/ea4eede60bbe9c63a348#5-%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC%E5%86%85%E3%81%A7%E9%96%A2%E6%95%B0%E3%82%92%E5%AE%9A%E7%BE%A9%E3%81%97%E3%81%AA%E3%81%84)
- [x] コンポーネントに子要素がない場合は **自己終了タグ** を利用する → [参考](https://qiita.com/baby-degu/items/ea4eede60bbe9c63a348#19-%E8%87%AA%E5%B7%B1%E7%B5%82%E4%BA%86%E3%82%BF%E3%82%B00)
- [x] attribute にブール値を直接記載する場合は省略形を利用する → [参考](https://qiita.com/baby-degu/items/ea4eede60bbe9c63a348#1-jsx%E3%81%AE%E7%9C%81%E7%95%A5%E5%BD%A2%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B)
- [x] attribute に文字列を直接記載する場合は波括弧を利用しない → [参考](https://qiita.com/baby-degu/items/ea4eede60bbe9c63a348#9-%E6%96%87%E5%AD%97%E5%88%97%E5%B1%9E%E6%80%A7%E3%81%AB%E6%B3%A2%E6%8B%AC%E5%BC%A7%E3%81%AF%E4%B8%8D%E8%A6%81)

### 共通 (その他)

- [x] フォーマット差分などは PR 上に一言 `インラインコメント` を付けて、レビュワーが省エネできるように → [参考](https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request)
