### PR TITLE
メニューのホバー時の動作と、要素の間隔の指定方法を修正しました。

### DIFF
--- a/components/AddMenuCard.tsx
+++ b/components/AddMenuCard.tsx
@@ -1,12 +1,12 @@
 export const AddMenuCard = (): JSX.Element => {
-    return (
-        <div className="border border-primary-regular border-dashed rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px]">
-            <div className="flex mt-[38.3%] mx-auto border-[3px] border-primary-regular rounded-full w-[26px] 2xl:w-[32px] h-[26px] 2xl:h-[32px]">
-                <div className="m-auto w-[60%] h-[15%] bg-thirdly-regular before:block before:rotate-90 before:w-[100%] before:h-[100%] before:content-[''] before:bg-thirdly-regular" />
-            </div>
-            <p className="mx-auto mt-[6.3%] text-[16px] 2xl:text-[19px] text-secondary-regular text-center">
-                メニューを追加
-            </p>
-        </div>
-    );
+  return (
+    <div className="border border-primary-regular border-dashed rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px]">
+      <div className="flex mt-[38.3%] mx-auto border-[3px] border-primary-regular rounded-full w-[26px] 2xl:w-[32px] h-[26px] 2xl:h-[32px]">
+        <div className="m-auto w-[60%] h-[15%] bg-thirdly-regular before:block before:rotate-90 before:w-[100%] before:h-[100%] before:content-[''] before:bg-thirdly-regular" />
+      </div>
+      <p className="mx-auto mt-[6.3%] text-[16px] 2xl:text-[19px] text-secondary-regular text-center">
+        メニューを追加
+      </p>
+    </div>
+  );
 };

--- a/components/AddMenuCard.tsx
+++ b/components/AddMenuCard.tsx
@@ -1,12 +1,12 @@
 export const AddMenuCard = (): JSX.Element => {
-  return (
-    <div className="mt-[48px] 2xl:mt-[58px] ml-[38px] 2xl:ml-[46px] border border-primary-regular border-dashed rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px]">
-      <div className="flex mt-[38.3%] mx-auto border-[3px] border-primary-regular rounded-full w-[26px] 2xl:w-[32px] h-[26px] 2xl:h-[32px]">
-        <div className="m-auto w-[60%] h-[15%] bg-thirdly-regular before:block before:rotate-90 before:w-[100%] before:h-[100%] before:content-[''] before:bg-thirdly-regular" />
-      </div>
-      <p className="mx-auto mt-[6.3%] text-[16px] 2xl:text-[19px] text-secondary-regular text-center">
-        メニューを追加
-      </p>
-    </div>
-  );
+    return (
+        <div className="border border-primary-regular border-dashed rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px]">
+            <div className="flex mt-[38.3%] mx-auto border-[3px] border-primary-regular rounded-full w-[26px] 2xl:w-[32px] h-[26px] 2xl:h-[32px]">
+                <div className="m-auto w-[60%] h-[15%] bg-thirdly-regular before:block before:rotate-90 before:w-[100%] before:h-[100%] before:content-[''] before:bg-thirdly-regular" />
+            </div>
+            <p className="mx-auto mt-[6.3%] text-[16px] 2xl:text-[19px] text-secondary-regular text-center">
+                メニューを追加
+            </p>
+        </div>
+    );
 };

--- a/components/MenuCard.tsx
+++ b/components/MenuCard.tsx
@@ -2,45 +2,49 @@ import classNames from "classnames";
 import { MenuContent } from "../types/MenuContent";
 
 interface Props {
-  content: MenuContent;
-  isSold: boolean;
+    content: MenuContent;
+    isSold: boolean;
 }
 
 export const MenuCard = ({ content, isSold }: Props): JSX.Element => {
-  return (
-    <div className="overflow-hidden mt-[48px] 2xl:mt-[58px] ml-[38px] 2xl:ml-[46px] rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px] shadow-regular cursor-pointer font-menu-card">
-      <div
-        className={classNames(
-          "flex items-center justify-center w-full h-[60.8%] text-[51px] 2xl:text-[61px]",
-          isSold ? "bg-reject-regular" : "bg-accent-secondary-light-regular"
-        )}
-      >
-        {content.ideogram}
-      </div>
-      <div className="mx-auto pt-[3.5%] pb-[4.4%] w-[89.5%] h-[39.2%] text-primary-regular">
-        <div className="flex items-center font-bold">
-          <p className="truncate w-[70%] text-[14px] 2xl:text-[17px]">
-            {content.name}
-          </p>
-          {isSold && (
-            <div className="ml-[auto] rounded-[3px] 2xl:rounded-[4px] px-[3.8%] py-[1.2%] text-[10px] bg-accent-primary-regular">
-              売り切れ
+    return (
+        <div className="overflow-hidden mt-[48px] 2xl:mt-[58px] ml-[38px] 2xl:ml-[46px] rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px] shadow-regular cursor-pointer font-menu-card hover:opacity-50">
+            <div
+                className={classNames(
+                    "flex items-center justify-center w-full h-[60.8%] text-[51px] 2xl:text-[61px]",
+                    isSold
+                        ? "bg-reject-regular"
+                        : "bg-accent-secondary-light-regular"
+                )}
+            >
+                {content.ideogram}
             </div>
-          )}
+            <div className="mx-auto pt-[3.5%] pb-[4.4%] w-[89.5%] h-[39.2%] text-primary-regular">
+                <div className="flex items-center font-bold">
+                    <p className="truncate w-[70%] text-[14px] 2xl:text-[17px]">
+                        {content.name}
+                    </p>
+                    {isSold && (
+                        <div className="ml-[auto] rounded-[3px] 2xl:rounded-[4px] px-[3.8%] py-[1.2%] text-[10px] bg-accent-primary-regular">
+                            売り切れ
+                        </div>
+                    )}
+                </div>
+                <p className="overflow-scroll my-[2.5%] h-[33%] text-[10px] leading-3 break-all">
+                    {content.promotion}
+                </p>
+                <div className="flex items-center">
+                    <p className="w-[60%] text-[10px] font-bold">
+                        単品 ￥
+                        <span className="text-[16px] 2xl:text-[19px]">
+                            {content.price}
+                        </span>
+                    </p>
+                    <button className="ml-[auto] rounded-[3px] 2xl:rounded-[4px] py-[1%] w-[36.4%] text-[10px] text-center bg-accent-secondary-regular">
+                        内容を編集
+                    </button>
+                </div>
+            </div>
         </div>
-        <p className="overflow-scroll my-[2.5%] h-[33%] text-[10px] leading-3 break-all">
-          {content.promotion}
-        </p>
-        <div className="flex items-center">
-          <p className="w-[60%] text-[10px] font-bold">
-            単品 ￥
-            <span className="text-[16px] 2xl:text-[19px]">{content.price}</span>
-          </p>
-          <button className="ml-[auto] rounded-[3px] 2xl:rounded-[4px] py-[1%] w-[36.4%] text-[10px] text-center bg-accent-secondary-regular">
-            内容を編集
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+    );
 };

--- a/components/MenuCard.tsx
+++ b/components/MenuCard.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export const MenuCard = ({ content, isSold }: Props): JSX.Element => {
     return (
-        <div className="overflow-hidden mt-[48px] 2xl:mt-[58px] ml-[38px] 2xl:ml-[46px] rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px] shadow-regular cursor-pointer font-menu-card hover:opacity-50">
+        <div className="overflow-hidden rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px] shadow-regular cursor-pointer font-menu-card hover:opacity-50">
             <div
                 className={classNames(
                     "flex items-center justify-center w-full h-[60.8%] text-[51px] 2xl:text-[61px]",

--- a/components/MenuCard.tsx
+++ b/components/MenuCard.tsx
@@ -2,49 +2,45 @@ import classNames from "classnames";
 import { MenuContent } from "../types/MenuContent";
 
 interface Props {
-    content: MenuContent;
-    isSold: boolean;
+  content: MenuContent;
+  isSold: boolean;
 }
 
 export const MenuCard = ({ content, isSold }: Props): JSX.Element => {
-    return (
-        <div className="overflow-hidden rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px] shadow-regular cursor-pointer font-menu-card hover:opacity-50">
-            <div
-                className={classNames(
-                    "flex items-center justify-center w-full h-[60.8%] text-[51px] 2xl:text-[61px]",
-                    isSold
-                        ? "bg-reject-regular"
-                        : "bg-accent-secondary-light-regular"
-                )}
-            >
-                {content.ideogram}
+  return (
+    <div className="overflow-hidden rounded-[19px] 2xl:rounded-[23px] w-[237px] 2xl:w-[284px] h-[247px] 2xl:h-[297px] shadow-regular cursor-pointer font-menu-card hover:opacity-50">
+      <div
+        className={classNames(
+          "flex items-center justify-center w-full h-[60.8%] text-[51px] 2xl:text-[61px]",
+          isSold ? "bg-reject-regular" : "bg-accent-secondary-light-regular"
+        )}
+      >
+        {content.ideogram}
+      </div>
+      <div className="mx-auto pt-[3.5%] pb-[4.4%] w-[89.5%] h-[39.2%] text-primary-regular">
+        <div className="flex items-center font-bold">
+          <p className="truncate w-[70%] text-[14px] 2xl:text-[17px]">
+            {content.name}
+          </p>
+          {isSold && (
+            <div className="ml-[auto] rounded-[3px] 2xl:rounded-[4px] px-[3.8%] py-[1.2%] text-[10px] bg-accent-primary-regular">
+              売り切れ
             </div>
-            <div className="mx-auto pt-[3.5%] pb-[4.4%] w-[89.5%] h-[39.2%] text-primary-regular">
-                <div className="flex items-center font-bold">
-                    <p className="truncate w-[70%] text-[14px] 2xl:text-[17px]">
-                        {content.name}
-                    </p>
-                    {isSold && (
-                        <div className="ml-[auto] rounded-[3px] 2xl:rounded-[4px] px-[3.8%] py-[1.2%] text-[10px] bg-accent-primary-regular">
-                            売り切れ
-                        </div>
-                    )}
-                </div>
-                <p className="overflow-scroll my-[2.5%] h-[33%] text-[10px] leading-3 break-all">
-                    {content.promotion}
-                </p>
-                <div className="flex items-center">
-                    <p className="w-[60%] text-[10px] font-bold">
-                        単品 ￥
-                        <span className="text-[16px] 2xl:text-[19px]">
-                            {content.price}
-                        </span>
-                    </p>
-                    <button className="ml-[auto] rounded-[3px] 2xl:rounded-[4px] py-[1%] w-[36.4%] text-[10px] text-center bg-accent-secondary-regular">
-                        内容を編集
-                    </button>
-                </div>
-            </div>
+          )}
         </div>
-    );
+        <p className="overflow-scroll my-[2.5%] h-[33%] text-[10px] leading-3 break-all">
+          {content.promotion}
+        </p>
+        <div className="flex items-center">
+          <p className="w-[60%] text-[10px] font-bold">
+            単品 ￥
+            <span className="text-[16px] 2xl:text-[19px]">{content.price}</span>
+          </p>
+          <button className="ml-[auto] rounded-[3px] 2xl:rounded-[4px] py-[1%] w-[36.4%] text-[10px] text-center bg-accent-secondary-regular">
+            内容を編集
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/pages/menu.tsx
+++ b/pages/menu.tsx
@@ -6,68 +6,71 @@ import { MenuContent } from "../types/MenuContent";
 
 //仮置きのデータ（実際はデータベースから取得する）
 const MenuContents: {
-  [key: string]: {
-    product: MenuContent;
-    isSold: boolean;
-  };
+    [key: string]: {
+        product: MenuContent;
+        isSold: boolean;
+    };
 } = {
-  hamburger1: {
-    product: {
-      ideogram: "🍔",
-      name: "ビーフバーガー１",
-      promotion:
-        "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
-      price: 490000,
+    hamburger1: {
+        product: {
+            ideogram: "🍔",
+            name: "ビーフバーガー１",
+            promotion:
+                "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
+            price: 490000,
+        },
+        isSold: false,
     },
-    isSold: false,
-  },
-  hamburger2: {
-    product: {
-      ideogram: "🍔",
-      name: "ビーフバーガー２",
-      promotion:
-        "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
-      price: 490000,
+    hamburger2: {
+        product: {
+            ideogram: "🍔",
+            name: "ビーフバーガー２",
+            promotion:
+                "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
+            price: 490000,
+        },
+        isSold: false,
     },
-    isSold: false,
-  },
-  hamburger3: {
-    product: {
-      ideogram: "🍔",
-      name: "ビーフバーガー３",
-      promotion:
-        "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
-      price: 490000,
+    hamburger3: {
+        product: {
+            ideogram: "🍔",
+            name: "ビーフバーガー３",
+            promotion:
+                "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
+            price: 490000,
+        },
+        isSold: true,
     },
-    isSold: true,
-  },
-  hamburger4: {
-    product: {
-      ideogram: "🍔",
-      name: "ビーフバーガー４",
-      promotion:
-        "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
-      price: 490000,
+    hamburger4: {
+        product: {
+            ideogram: "🍔",
+            name: "ビーフバーガー４",
+            promotion:
+                "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
+            price: 490000,
+        },
+        isSold: false,
     },
-    isSold: false,
-  },
 };
 
 const Menu: NextPage = () => {
-  return (
-    <FeatureLayout type="menu">
-      <ul className="flex flex-wrap ml-[-38px] 2xl:ml-[-46px]">
-        {Object.values(MenuContents).map((content) => (
-          <li key={content.product.name}>
-            <MenuCard content={content.product} isSold={content.isSold} />
-          </li>
-        ))}
-        <li key="add-menu-card">
-          <AddMenuCard />
-        </li>
-      </ul>
-    </FeatureLayout>
-  );
+    return (
+        <FeatureLayout type="menu">
+            <ul className="flex flex-wrap ml-[-38px] 2xl:ml-[-46px] gap-y-[48px] 2xl:gap-y-[58px] gap-x-[38px] 2xl:gap-x-[46px]">
+                {Object.values(MenuContents).map((content) => (
+                    <li key={content.product.name}>
+                        <MenuCard
+                            content={content.product}
+                            isSold={content.isSold}
+                        />
+                    </li>
+                ))}
+                <li key="add-menu-card">
+                    <AddMenuCard />
+                </li>
+            </ul>
+        </FeatureLayout>
+    );
 };
 
 export default Menu;

--- a/pages/menu.tsx
+++ b/pages/menu.tsx
@@ -6,71 +6,68 @@ import { MenuContent } from "../types/MenuContent";
 
 //仮置きのデータ（実際はデータベースから取得する）
 const MenuContents: {
-    [key: string]: {
-        product: MenuContent;
-        isSold: boolean;
-    };
+  [key: string]: {
+    product: MenuContent;
+    isSold: boolean;
+  };
 } = {
-    hamburger1: {
-        product: {
-            ideogram: "🍔",
-            name: "ビーフバーガー１",
-            promotion:
-                "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
-            price: 490000,
-        },
-        isSold: false,
+  hamburger1: {
+    product: {
+      ideogram: "🍔",
+      name: "ビーフバーガー１",
+      promotion:
+        "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
+      price: 490000,
     },
-    hamburger2: {
-        product: {
-            ideogram: "🍔",
-            name: "ビーフバーガー２",
-            promotion:
-                "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
-            price: 490000,
-        },
-        isSold: false,
+    isSold: false,
+  },
+  hamburger2: {
+    product: {
+      ideogram: "🍔",
+      name: "ビーフバーガー２",
+      promotion:
+        "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
+      price: 490000,
     },
-    hamburger3: {
-        product: {
-            ideogram: "🍔",
-            name: "ビーフバーガー３",
-            promotion:
-                "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
-            price: 490000,
-        },
-        isSold: true,
+    isSold: false,
+  },
+  hamburger3: {
+    product: {
+      ideogram: "🍔",
+      name: "ビーフバーガー３",
+      promotion:
+        "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
+      price: 490000,
     },
-    hamburger4: {
-        product: {
-            ideogram: "🍔",
-            name: "ビーフバーガー４",
-            promotion:
-                "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
-            price: 490000,
-        },
-        isSold: false,
+    isSold: true,
+  },
+  hamburger4: {
+    product: {
+      ideogram: "🍔",
+      name: "ビーフバーガー４",
+      promotion:
+        "おいしさも食べごたえもビッグな人気メニュー、ビッグマック。パティが倍でそのビッグな食べごたえもボリュームアップ。",
+      price: 490000,
     },
+    isSold: false,
+  },
 };
 
 const Menu: NextPage = () => {
-    return (
-        <FeatureLayout type="menu">
-            <ul className="flex flex-wrap pt-[48px] 2xl:pt-[58px] gap-y-[48px] 2xl:gap-y-[58px] gap-x-[38px] 2xl:gap-x-[46px]">
-                {Object.values(MenuContents).map((content) => (
-                    <li key={content.product.name}>
-                        <MenuCard
-                            content={content.product}
-                            isSold={content.isSold}
-                        />
-                    </li>
-                ))}
-                <li key="add-menu-card">
-                    <AddMenuCard />
-                </li>
-            </ul>
-        </FeatureLayout>
-    );
+  return (
+    <FeatureLayout type="menu">
+      <ul className="flex flex-wrap pt-[48px] 2xl:pt-[58px] gap-y-[48px] 2xl:gap-y-[58px] gap-x-[38px] 2xl:gap-x-[46px]">
+        {Object.values(MenuContents).map((content) => (
+          <li key={content.product.name}>
+            <MenuCard content={content.product} isSold={content.isSold} />
+          </li>
+        ))}
+        <li key="add-menu-card">
+          <AddMenuCard />
+        </li>
+      </ul>
+    </FeatureLayout>
+  );
 };
 
 export default Menu;

--- a/pages/menu.tsx
+++ b/pages/menu.tsx
@@ -56,7 +56,7 @@ const MenuContents: {
 const Menu: NextPage = () => {
     return (
         <FeatureLayout type="menu">
-            <ul className="flex flex-wrap ml-[-38px] 2xl:ml-[-46px] gap-y-[48px] 2xl:gap-y-[58px] gap-x-[38px] 2xl:gap-x-[46px]">
+            <ul className="flex flex-wrap pt-[48px] 2xl:pt-[58px] gap-y-[48px] 2xl:gap-y-[58px] gap-x-[38px] 2xl:gap-x-[46px]">
                 {Object.values(MenuContents).map((content) => (
                     <li key={content.product.name}>
                         <MenuCard


### PR DESCRIPTION
<!-- https://github.com/Conken-NitKit/github-template-example/blob/main/.github/PULL_REQUEST_TEMPLATE_REACT.md より -->

## 概要

<!-- 今回のPRの 実装内容 & 変更するに至った背景 を記載してください。 -->
#41の内容を実装しました。

## デバッグ項目
<!--
実装に不具合がないことを確認するために行った項目です。

- [ ] 入力例 1
- [ ] 入力例 2
-->

- [x] メニューは正常に動作しています。
- [x] レスポンシブは正常に動作しています。 
- [x] コンソールに警告はありません。
- [x] 外観に大きな違和感はありません。

## スクリーンショット

<!--
実際にどのような表示かの写真を貼り付ける項目です。
動画の場合は下記の表を消して、[この記事](https://zenn.dev/naminodarie/articles/27f9c260fd81fd)を参考に動画を追加してください。
-->

|             Before              |              After              |
| :-----------------------------: | :-----------------------------: |
| <img width="450" alt="" src="https://user-images.githubusercontent.com/111258079/191014965-0ff178d2-8892-44b6-bf78-ed2b832c2f31.png"> | <img width="450" alt="" src="https://user-images.githubusercontent.com/111258079/191015315-67144159-bebd-4814-b5ec-2450b76d19a5.png"> |

## 参考 URL

<!--
参考にした記事があれば、そのURLを記載してください。

- 参考にしたURL 1
- 参考にしたURL 2
-->

## Self-Checking points 🚨

レビューを依頼する前に必ず確認してほしいポイントです。
一般的な項目を上げているので、プロジェクト毎に必要なポイントがあれば各リポジトリで追加してください。

### 共通 (命名)

- [x] `data`, `info`, `value` などの汎用的で抽象度の高い変数名を使っていない → [参考](https://neos21.net/blog/2020/01/28-01.html)
- [x] 配列には末尾に `s` をつけて複数形にするか `xxxList` と命名することで配列であることを明確にしている → [参考](https://teratail.com/questions/161176)
- [x] マジックナンバーは極力存在せず、定数を用いて表現されている [参考](https://twitter.com/program_shiba/status/1483378634975072260)
- [x] パッと見で何をやってるかわからないような処理の結果を **説明変数** している → [参考](https://wb-hp.com/blog/2020/11/09/explanatory-variable.html)
- [x] 複雑な条件式の結果を **要約変数** を適用している → [参考](https://twitter.com/hakuto00/status/1362608154840760320)

### 共通 (処理系)

- [x] **早期リターン（ガード節）** を適用することで条件分岐の簡略化している → [参考](https://zenn.dev/media_engine/articles/early_return)
- [x] if 文では「調査対象」を左側に、「比較対象」を右側に配置している → [参考](https://twitter.com/yuuuma_11/status/1347374986160340992/photo/2)
- [x] 値のパターンによって分岐する場合は `is/else文` ではなく、`switch文` を使う → [参考](https://blog.senseshare.jp/if-switch.html)

### 共通 (コメント系)

- [x] コメントには適切なアノテーションコメントが記載されている → [参考](https://qiita.com/taka-kawa/items/673716d77795c937d422)

### JavaScript (命名)

- [x] 変数名, 関数名, プロパティ名 は `ローワーキャメルケース` になっている → [参考](https://qiita.com/RyosukeSomeya/items/90f8e780b37c53758276)
- [x] クラス名, オブジェクト名 は `パスカルケース` になっている → [参考](https://qiita.com/RyosukeSomeya/items/90f8e780b37c53758276)
- [x] 定数名は `スネークケース` になっている → [参考](https://qiita.com/RyosukeSomeya/items/90f8e780b37c53758276)

### JavaScript (処理系)

- [x] 変数の宣言には極力を `const` を利用している → [参考](https://qiita.com/cheez921/items/7b57835cb76e70dd0fc4)
- [x] 文字列の合成にはテンプレートリテラルを利用している → [参考](https://qiita.com/kitamuwork/items/6830c1fe2399f35fce8d)
- [x] ループ処理は `通常for文`, `for-in`, `forEach` などは極力利用せず、高階関数を利用している → [参考](https://qiita.com/may88seiji/items/8f7e42353b6904af5e9a)
- [x] `==(等価演算子)` は使わず `===(厳密等価演算子)` を利用している → [参考](https://code-graffiti.com/equality-operators-in-javascript/)

### TypeScript (命名)

- [x] インターフェース, タイプ, Enum の命名は `パスカルケース` になっている → [参考](https://typescript-jp.gitbook.io/deep-dive/styleguide)

### React (処理系)

- [x] コンポーネントの変数名は `パスカルケース` になっている → [参考](https://qiita.com/RyosukeSomeya/items/90f8e780b37c53758276)
- [x] イベント処理のロジックは JSX 内に直接かかず、コールバック関数として JSX 外で定義する → [参考](https://qiita.com/baby-degu/items/ea4eede60bbe9c63a348#5-%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC%E5%86%85%E3%81%A7%E9%96%A2%E6%95%B0%E3%82%92%E5%AE%9A%E7%BE%A9%E3%81%97%E3%81%AA%E3%81%84)
- [x] コンポーネントに子要素がない場合は **自己終了タグ** を利用する → [参考](https://qiita.com/baby-degu/items/ea4eede60bbe9c63a348#19-%E8%87%AA%E5%B7%B1%E7%B5%82%E4%BA%86%E3%82%BF%E3%82%B00)
- [x] attribute にブール値を直接記載する場合は省略形を利用する → [参考](https://qiita.com/baby-degu/items/ea4eede60bbe9c63a348#1-jsx%E3%81%AE%E7%9C%81%E7%95%A5%E5%BD%A2%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B)
- [x] attribute に文字列を直接記載する場合は波括弧を利用しない → [参考](https://qiita.com/baby-degu/items/ea4eede60bbe9c63a348#9-%E6%96%87%E5%AD%97%E5%88%97%E5%B1%9E%E6%80%A7%E3%81%AB%E6%B3%A2%E6%8B%AC%E5%BC%A7%E3%81%AF%E4%B8%8D%E8%A6%81)

### 共通 (その他)

- [x] フォーマット差分などは PR 上に一言 `インラインコメント` を付けて、レビュワーが省エネできるように → [参考](https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request)
